### PR TITLE
Redirect unauthenticated users

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,21 +10,54 @@ import HomePage from './pages/home/HomePageBeforeLogin';
 import ProfileSetUpPage from './pages/auth/EditProfilePage';
 import MessagesPage from './pages/home/MessagesPage';
 
+import ProtectedRoute from './routes/ProtectedRoute';
+
 const App = () => {
   return (
     <div className="min-h-screen flex justify-center items-center bg-gray-100">
       <Routes>
-        <Route path= '/' element={<HomePage />}/>
-				<Route path='/login' element={<LoginPage />} />
-				<Route path='/signup' element={<SignUpPage/>} />
-        <Route path="/edit-profile" element={<ProfileSetUpPage />} />
-        <Route path="/home" element={<MainPageAfterLogin />} />
-        <Route path="/profile" element={<ProfilePage/>}/>
-        <Route path="/chats" element={<MessagesPage/>}/>
-			</Routes>
-      <Toaster/>
+        {/* Public routes */}
+        <Route path="/" element={<HomePage />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/signup" element={<SignUpPage />} />
+
+        {/* Protected routes */}
+        <Route
+          path="/edit-profile"
+          element={
+            <ProtectedRoute>
+              <ProfileSetUpPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/home"
+          element={
+            <ProtectedRoute>
+              <MainPageAfterLogin />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/profile"
+          element={
+            <ProtectedRoute>
+              <ProfilePage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/chats"
+          element={
+            <ProtectedRoute>
+              <MessagesPage />
+            </ProtectedRoute>
+          }
+        />
+      </Routes>
+      <Toaster />
     </div>
-  );
+  );  
 };
 
 export default App;

--- a/frontend/src/components/layout/AppBar.tsx
+++ b/frontend/src/components/layout/AppBar.tsx
@@ -61,7 +61,7 @@ const MyAppBar: React.FC = () => {
         </div>
 
         {/* Right section: SearchBar & ProfilePic / Sign In Button */}
-        {!!user ? (
+        {user ? (
           <div className="flex items-center h-full left-3">
             <div className="relative h-[35px]">
               <input

--- a/frontend/src/components/layout/AppBar.tsx
+++ b/frontend/src/components/layout/AppBar.tsx
@@ -15,6 +15,14 @@ const MyAppBar: React.FC = () => {
   const navigate = useNavigate();
   const { user } = useUserContext();
 
+  const protectedNavigate = (path: string) => {
+    if (!user) {
+      navigate('/login');
+    } else {
+      navigate(path);
+    }
+  };
+  
   return (
     <div className="bg-[#e4f3ec] text-white shadow-md w-full h-[56px] fixed top-0 left-0 right-0 z-50">
       <div className="flex items-center justify-between h-full px-4">
@@ -22,7 +30,8 @@ const MyAppBar: React.FC = () => {
         <div className="flex items-center h-full">
           <div
             className="flex items-center cursor-pointer"
-            onClick={() => navigate('/home')} // Navigate to /home on click
+            
+            onClick={() => protectedNavigate('/home')} // Navigate to /home on click. If the user is not logged in, redirects to login page.
           >
             <img src={logo} alt="App Logo" className="w-[44px] h-[34px]" />
             <span className="text-2xl font-bold ml-2 font-poppins italic text-black">StuCo</span>

--- a/frontend/src/routes/ProtectedRoute.tsx
+++ b/frontend/src/routes/ProtectedRoute.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useUserContext } from '../context/UserContext';
+
+interface ProtectedRouteProps {
+  children: JSX.Element;
+}
+
+const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
+  const { user } = useUserContext();
+
+  // If the user is not logged in, redirect to the login page
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return children;
+};
+
+export default ProtectedRoute;


### PR DESCRIPTION
Fixes #25 by 
1. Instead of redirecting to homepage after login, redirecting unauthenticated users to login page upon clicking the app logo. Since other toolbar pages (such as Explore, Mentorship, etc) are not implemented yet, they were left untouched.
2. Prevent unauthenticated users from accessing the protected URLs by typing (such as /home, /chats, etc.). 